### PR TITLE
restart apache during install

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,8 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get update \
   && apt-get -y --force-yes install apache2 imagemagick software-properties-common \
   && apt-get clean \
   && rm -rf /var/lib/apt/lists/* \
-  && a2enmod rewrite
+  && a2enmod rewrite \
+	&& service apache2 restart
 
 COPY ./files/omeka-2.4.1/ /app/
 RUN chmod -R a+rwx /app/files


### PR DESCRIPTION
a2enmod installs mod_rewrite, but it seems to require an explicit restart to make it pick it up.
